### PR TITLE
Use std threads for peerconnection bulk traffic

### DIFF
--- a/examples/peerconnection/client/sctp_traffic/bulk/bulk_receiver.cc
+++ b/examples/peerconnection/client/sctp_traffic/bulk/bulk_receiver.cc
@@ -1,36 +1,51 @@
 #include "sctp_traffic/bulk/bulk_receiver.h"
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
 #include "examples/peerconnection/client/conductor.h"
-#include "rtc_base/time_utils.h"
-#include "rtc_base/logging.h"
+
+namespace {
+int64_t NowMillis() {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+}  // namespace
 
 using Kind = Conductor::TrafficKind;
 
 namespace sctp::bulk {
 
 Receiver::Receiver(int log_period_ms) : period_ms_(log_period_ms) {}
-Receiver::~Receiver() { Detach(); }
+Receiver::~Receiver() {
+  Detach();
+}
 
 void Receiver::Attach(Conductor& c) {
   conductor_ = &c;
 
   // 1) Register payload handler
   conductor_->RegisterPayloadHandler(Kind::kBulkTest,
-      [this](absl::Span<const uint8_t> bytes) {
-        rx_accum_ += bytes.size();
-        rx_total_ += bytes.size();
-      });
+                                     [this](absl::Span<const uint8_t> bytes) {
+                                       rx_accum_ += bytes.size();
+                                       rx_total_ += bytes.size();
+                                     });
 
   // 2) Periodic log timer
-  last_ms_ = rtc::TimeMillis();
-  task_ = webrtc::RepeatingTaskHandle::Start(
-      *conductor_->signaling_thread(), [this]() {
-        Tick();
-        return webrtc::TimeDelta::Millis(period_ms_);
-      });
+  last_ms_ = NowMillis();
+  running_.store(true);
+  worker_ = std::thread([this]() {
+    while (running_.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(period_ms_));
+      Tick();
+    }
+  });
 }
 
 void Receiver::Tick() {
-  const int64_t now = rtc::TimeMillis();
+  const int64_t now = NowMillis();
   const double dt = (now - last_ms_) / 1000.0;
   last_ms_ = now;
 
@@ -38,14 +53,15 @@ void Receiver::Tick() {
   rx_accum_ = 0;
   const double mbps = dt > 0 ? (bytes * 8.0) / (dt * 1e6) : 0.0;
 
-  RTC_LOG(LS_INFO) << "[BULK][RX] " << mbps << " Mbps ("
-                   << bytes << " B / " << dt << " s), total="
-                   << rx_total_ << " B";
+  std::cout << "[BULK][RX] " << mbps << " Mbps (" << bytes << " B / " << dt
+            << " s), total=" << rx_total_ << " B" << std::endl;
 }
 
 void Receiver::Detach() {
-  if (task_.Running()) task_.Stop();
+  running_.store(false);
+  if (worker_.joinable())
+    worker_.join();
   conductor_ = nullptr;
 }
 
-} // namespace sctp::bulk
+}  // namespace sctp::bulk

--- a/examples/peerconnection/client/sctp_traffic/bulk/bulk_receiver.h
+++ b/examples/peerconnection/client/sctp_traffic/bulk/bulk_receiver.h
@@ -1,33 +1,34 @@
 #pragma once
+#include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <thread>
+
 #include "sctp_traffic/traffic.h"
-#include "rtc_base/task_utils/repeating_task.h"
-#include "api/task_queue/task_queue_base.h"
-#include "api/task_queue/task_queue_factory.h"
-#include "api/task_queue/default_task_queue_factory.h"
 
 class Conductor;
 
 namespace sctp::bulk {
 
 class Receiver final : public sctp::Receiver {
-public:
+ public:
   explicit Receiver(int log_period_ms = 1000);
   ~Receiver() override;
 
   void Attach(Conductor& c) override;
   void Detach() override;
 
-private:
+ private:
   void Tick();
 
   Conductor* conductor_ = nullptr;
   int period_ms_;
-  webrtc::RepeatingTaskHandle task_;
+  std::thread worker_;
+  std::atomic<bool> running_{false};
 
   uint64_t rx_accum_ = 0;
   uint64_t rx_total_ = 0;
-  int64_t  last_ms_  = 0;
+  int64_t last_ms_ = 0;
 };
 
-} // namespace sctp::bulk
+}  // namespace sctp::bulk

--- a/examples/peerconnection/client/sctp_traffic/bulk/bulk_sender.cc
+++ b/examples/peerconnection/client/sctp_traffic/bulk/bulk_sender.cc
@@ -1,14 +1,27 @@
 #include "sctp_traffic/bulk/bulk_sender.h"
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
 #include "examples/peerconnection/client/conductor.h"
-#include "rtc_base/time_utils.h"
-#include "rtc_base/logging.h"
+
+namespace {
+int64_t NowMillis() {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+}  // namespace
 
 using Kind = Conductor::TrafficKind;
 
 namespace sctp::bulk {
 
 Sender::Sender(Config cfg) : cfg_(cfg) {}
-Sender::~Sender() { Stop(); }
+Sender::~Sender() {
+  Stop();
+}
 
 void Sender::Start(Conductor& c) {
   conductor_ = &c;
@@ -17,48 +30,57 @@ void Sender::Start(Conductor& c) {
   payload_.assign(cfg_.chunk_bytes, 0x00);
 
   credit_bytes_ = 0.0;
-  last_ms_ = rtc::TimeMillis();
+  last_ms_ = NowMillis();
 
-  if (task_.Running()) task_.Stop();
-  task_ = webrtc::RepeatingTaskHandle::Start(
-      *conductor_->signaling_thread(), [this]() {
-        PumpOnce(rtc::TimeMillis());
-        return webrtc::TimeDelta::Millis(cfg_.pump_interval_ms);
-      });
+  running_.store(true);
+  worker_ = std::thread([this]() {
+    while (running_.load()) {
+      PumpOnce(NowMillis());
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(cfg_.pump_interval_ms));
+    }
+  });
 
-  RTC_LOG(LS_INFO) << "[BULK][TX] started: " << cfg_.target_mbps
-                   << " Mbps, chunk=" << cfg_.chunk_bytes << " B";
+  std::cout << "[BULK][TX] started: " << cfg_.target_mbps
+            << " Mbps, chunk=" << cfg_.chunk_bytes << " B" << std::endl;
 }
 
 void Sender::Stop() {
-  if (task_.Running()) task_.Stop();
+  running_.store(false);
+  if (worker_.joinable())
+    worker_.join();
   conductor_ = nullptr;
-  RTC_LOG(LS_INFO) << "[BULK][TX] stopped";
+  std::cout << "[BULK][TX] stopped" << std::endl;
 }
 
 void Sender::PumpOnce(int64_t now_ms) {
-  if (!conductor_ || !conductor_->IsFlowOpen(Kind::kBulkTest)) return;
+  if (!conductor_ || !conductor_->IsFlowOpen(Kind::kBulkTest))
+    return;
 
   const double dt = (now_ms - last_ms_) / 1000.0;
   last_ms_ = now_ms;
   credit_bytes_ += target_bps_ * dt / 8.0;
 
-  if (conductor_->BufferedAmount(Kind::kBulkTest) > cfg_.buffered_cap) return;
+  if (conductor_->BufferedAmount(Kind::kBulkTest) > cfg_.buffered_cap)
+    return;
 
   size_t sent_bytes = 0;
   while (credit_bytes_ >= static_cast<double>(payload_.size())) {
-    conductor_->SendPayload(Kind::kBulkTest, absl::Span<const uint8_t>(payload_.data(), payload_.size()));
+    conductor_->SendPayload(
+        Kind::kBulkTest,
+        absl::Span<const uint8_t>(payload_.data(), payload_.size()));
     credit_bytes_ -= payload_.size();
     sent_bytes += payload_.size();
 
-    if (conductor_->BufferedAmount(Kind::kBulkTest) > cfg_.buffered_cap) break;
+    if (conductor_->BufferedAmount(Kind::kBulkTest) > cfg_.buffered_cap)
+      break;
   }
 
   if (sent_bytes > 0 && dt > 0) {
     const double mbps = (sent_bytes * 8.0) / (dt * 1e6);
-    RTC_LOG(LS_VERBOSE) << "[BULK][TX] ~" << mbps << " Mbps, buffered="
-                        << conductor_->BufferedAmount(Kind::kBulkTest);
+    std::cout << "[BULK][TX] ~" << mbps << " Mbps, buffered="
+              << conductor_->BufferedAmount(Kind::kBulkTest) << std::endl;
   }
 }
 
-} // namespace sctp::bulk
+}  // namespace sctp::bulk

--- a/examples/peerconnection/client/sctp_traffic/bulk/bulk_sender.h
+++ b/examples/peerconnection/client/sctp_traffic/bulk/bulk_sender.h
@@ -1,10 +1,10 @@
 #pragma once
+#include <atomic>
+#include <cstdint>
+#include <thread>
 #include <vector>
+
 #include "sctp_traffic/traffic.h"
-#include "rtc_base/task_utils/repeating_task.h"
-#include "api/task_queue/task_queue_base.h"
-#include "api/task_queue/task_queue_factory.h"
-#include "api/task_queue/default_task_queue_factory.h"
 
 class Conductor;
 
@@ -18,19 +18,20 @@ struct Config {
 };
 
 class Sender final : public sctp::Sender {
-public:
+ public:
   explicit Sender(Config cfg = {});
   ~Sender() override;
 
   void Start(Conductor& c) override;
   void Stop() override;
 
-private:
+ private:
   void PumpOnce(int64_t now_ms);
 
   Conductor* conductor_ = nullptr;
   Config cfg_;
-  webrtc::RepeatingTaskHandle task_;
+  std::thread worker_;
+  std::atomic<bool> running_{false};
 
   std::vector<uint8_t> payload_;
   double target_bps_ = 0.0;
@@ -38,4 +39,4 @@ private:
   int64_t last_ms_ = 0;
 };
 
-} // namespace sctp::bulk
+}  // namespace sctp::bulk


### PR DESCRIPTION
## Summary
- remove RTC task APIs from bulk sender and receiver
- implement iperf-style loops using std::thread and chrono

## Testing
- `python3 presubmit_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b50af32a008327b17f41d2d98955d5