### PR TITLE
Add SCTP throughput logging and plotting utilities

### DIFF
--- a/examples/peerconnection/client/conductor.cc
+++ b/examples/peerconnection/client/conductor.cc
@@ -1333,7 +1333,7 @@ void Conductor::AddSCTPs() {
   //AddSctpFlow(TrafficKind::kMesh,     "mesh", lowprio);
 
   if (!bulk_receiver_) {
-    bulk_receiver_ = std::make_unique<sctp::bulk::Receiver>();
+    bulk_receiver_ = std::make_unique<sctp::bulk::Receiver>(log_dir_);
     bulk_receiver_->Attach(*this);
   }
 }
@@ -1350,6 +1350,8 @@ void Conductor::DisconnectFromCurrentPeer() {
 }
 
 void Conductor::StartBulkSctp() {
+  if (bulk_receiver_)
+    bulk_receiver_->LogStart();
   const std::string cmd = "start";
   SendPayload(TrafficKind::kControl,
               absl::Span<const uint8_t>(
@@ -1357,6 +1359,8 @@ void Conductor::StartBulkSctp() {
 }
 
 void Conductor::StopBulkSctp() {
+  if (bulk_receiver_)
+    bulk_receiver_->LogStop();
   const std::string cmd = "stop";
   SendPayload(TrafficKind::kControl,
               absl::Span<const uint8_t>(

--- a/examples/peerconnection/client/sctp_traffic/bulk/bulk_receiver.cc
+++ b/examples/peerconnection/client/sctp_traffic/bulk/bulk_receiver.cc
@@ -18,7 +18,15 @@ using Kind = Conductor::TrafficKind;
 
 namespace sctp::bulk {
 
-Receiver::Receiver(int log_period_ms) : period_ms_(log_period_ms) {}
+Receiver::Receiver(const std::string& log_dir, int log_period_ms)
+    : period_ms_(log_period_ms) {
+  std::string path = log_dir + "/sctp_traffic.csv";
+  log_file_.open(path);
+  if (log_file_.is_open()) {
+    log_file_ << "Time,Throughput,Start,Stop\n";
+    log_file_.flush();
+  }
+}
 Receiver::~Receiver() {
   Detach();
 }
@@ -53,6 +61,11 @@ void Receiver::Tick() {
   rx_accum_ = 0;
   const double mbps = dt > 0 ? (bytes * 8.0) / (dt * 1e6) : 0.0;
 
+  if (logging_.load() && log_file_.is_open()) {
+    log_file_ << now << "," << mbps << ",0,0\n";
+    log_file_.flush();
+  }
+
   std::cout << "[BULK][RX] " << mbps << " Mbps (" << bytes << " B / " << dt
             << " s), total=" << rx_total_ << " B" << std::endl;
 }
@@ -62,6 +75,29 @@ void Receiver::Detach() {
   if (worker_.joinable())
     worker_.join();
   conductor_ = nullptr;
+  if (log_file_.is_open()) {
+    log_file_.close();
+  }
+}
+
+void Receiver::LogStart() {
+  int64_t now = NowMillis();
+  if (log_file_.is_open()) {
+    log_file_ << now << ",0,1,0\n";
+    log_file_.flush();
+  }
+  rx_accum_ = 0;
+  last_ms_ = now;
+  logging_.store(true);
+}
+
+void Receiver::LogStop() {
+  int64_t now = NowMillis();
+  if (log_file_.is_open()) {
+    log_file_ << now << ",0,0,1\n";
+    log_file_.flush();
+  }
+  logging_.store(false);
 }
 
 }  // namespace sctp::bulk

--- a/examples/peerconnection/client/sctp_traffic/bulk/bulk_receiver.h
+++ b/examples/peerconnection/client/sctp_traffic/bulk/bulk_receiver.h
@@ -2,6 +2,8 @@
 #include <atomic>
 #include <chrono>
 #include <cstdint>
+#include <fstream>
+#include <string>
 #include <thread>
 
 #include "sctp_traffic/traffic.h"
@@ -12,11 +14,15 @@ namespace sctp::bulk {
 
 class Receiver final : public sctp::Receiver {
  public:
-  explicit Receiver(int log_period_ms = 1000);
+  Receiver(const std::string& log_dir, int log_period_ms = 1000);
   ~Receiver() override;
 
   void Attach(Conductor& c) override;
   void Detach() override;
+
+  // Log start/stop events triggered by UI buttons.
+  void LogStart();
+  void LogStop();
 
  private:
   void Tick();
@@ -29,6 +35,9 @@ class Receiver final : public sctp::Receiver {
   uint64_t rx_accum_ = 0;
   uint64_t rx_total_ = 0;
   int64_t last_ms_ = 0;
+
+  std::ofstream log_file_;
+  std::atomic<bool> logging_{false};
 };
 
 }  // namespace sctp::bulk

--- a/src/plot_webrtc_logs.py
+++ b/src/plot_webrtc_logs.py
@@ -1,0 +1,78 @@
+import argparse
+import csv
+import os
+from typing import List
+
+import matplotlib.pyplot as plt
+
+
+def read_column(path: str, column: str) -> List[float]:
+    with open(path, newline="") as f:
+        reader = csv.DictReader(f)
+        return [float(row[column]) for row in reader]
+
+
+def read_csv(path: str) -> List[dict]:
+    with open(path, newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Plot RTP bitrate and SCTP throughput"
+    )
+    parser.add_argument(
+        "log_dir",
+        help="Receiver log directory containing average_stats.csv and sctp_traffic.csv",
+    )
+    parser.add_argument("--output", default="webrtc_plot.png", help="Output image filename")
+    args = parser.parse_args()
+
+    avg_path = os.path.join(args.log_dir, "average_stats.csv")
+    sctp_path = os.path.join(args.log_dir, "sctp_traffic.csv")
+
+    if not os.path.exists(avg_path) or not os.path.exists(sctp_path):
+        raise FileNotFoundError(f"Log files not found in {args.log_dir}")
+
+    avg_rows = read_csv(avg_path)
+    sctp_rows = read_csv(sctp_path)
+
+    avg_times = [
+        (float(r["timestamp_ms"]) - float(avg_rows[0]["timestamp_ms"])) / 1000.0
+        for r in avg_rows
+    ]
+    bitrates = [float(r["bitrates"]) / 1e6 for r in avg_rows]
+
+    sctp_times = [
+        (float(r["Time"]) - float(sctp_rows[0]["Time"])) / 1000.0
+        for r in sctp_rows
+    ]
+    throughput = [float(r["Throughput"]) for r in sctp_rows]
+
+    fig, ax = plt.subplots()
+    ax.plot(avg_times, bitrates, label="RTP Bitrate (Mbps)")
+    ax.plot(sctp_times, throughput, label="SCTP Throughput (Mbps)")
+
+    start_drawn = stop_drawn = False
+    for r, t in zip(sctp_rows, sctp_times):
+        if r.get("Start") == "1" and not start_drawn:
+            ax.axvline(t, color="green", linestyle="--", label="Start")
+            start_drawn = True
+        elif r.get("Start") == "1":
+            ax.axvline(t, color="green", linestyle="--")
+        if r.get("Stop") == "1" and not stop_drawn:
+            ax.axvline(t, color="red", linestyle="--", label="Stop")
+            stop_drawn = True
+        elif r.get("Stop") == "1":
+            ax.axvline(t, color="red", linestyle="--")
+
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Rate (Mbps)")
+    ax.legend()
+    plt.tight_layout()
+    plt.savefig(args.output)
+    print(f"Plot saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- log SCTP bulk transfer start/stop events and per-second throughput on receiver
- expose start/stop hooks in conductor and write CSV logs
- add Python script to plot RTP bitrate and SCTP throughput with start/stop markers

## Testing
- `python -m py_compile src/plot_webrtc_logs.py`
- `python presubmit_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6299953248327bf8809ddc3e99d26